### PR TITLE
Allow reusing the sanitation in plugins and themes by breaking up the code into more manageable chunks

### DIFF
--- a/wp_query-route-to-rest-api.php
+++ b/wp_query-route-to-rest-api.php
@@ -4,7 +4,7 @@
  * Description: Adds new route /wp-json/wp_query/args/ to REST API
  * Author: Aucor
  * Author URI: https://www.aucor.fi/
- * Version: 1.1.1
+ * Version: 1.2.1
  * License: GPL2+
  **/
 
@@ -51,16 +51,7 @@ class WP_Query_Route_To_REST_API extends WP_REST_Posts_Controller {
     return apply_filters( 'wp_query_route_to_rest_api_permissions_check', true, $request );
   }
 
-  /**
-   * Get a collection of items
-   *
-   * @param WP_REST_Request $request Full data about the request.
-   */
-
-  public function get_items( $request ) {
-
-    $parameters = $request->get_query_params();
-
+  public function sanitize_query_parameters ( $parameters ) {
     $default_args = array(
       'post_status'     => 'publish',
       'posts_per_page'  => 10,
@@ -105,7 +96,7 @@ class WP_Query_Route_To_REST_API extends WP_REST_Posts_Controller {
       'post_mime_type',
       'lang', // Polylang
     );
-    
+
 
     // Allow filtering by author: default yes
     if( apply_filters( 'wp_query_toute_to_rest_api_allow_authors', true ) ) {
@@ -163,7 +154,7 @@ class WP_Query_Route_To_REST_API extends WP_REST_Posts_Controller {
           case 'post_type':
 
             // Multiple values
-            if( is_array( $value ) ) { 
+            if( is_array( $value ) ) {
               foreach ( $value as $sub_key => $sub_value ) {
                 // Bail if there's even one post type that's not allowed
                 if( !$this->check_is_post_type_allowed( $sub_value ) ) {
@@ -201,7 +192,7 @@ class WP_Query_Route_To_REST_API extends WP_REST_Posts_Controller {
           case 'posts_status':
 
             // Multiple values
-            if( is_array( $value ) ) { 
+            if( is_array( $value ) ) {
               foreach ( $value as $sub_key => $sub_value ) {
                 // Bail if there's even one post status that's not allowed
                 if( !$this->check_is_post_status_allowed( $sub_value ) ) {
@@ -240,6 +231,12 @@ class WP_Query_Route_To_REST_API extends WP_REST_Posts_Controller {
       $args[$key] = apply_filters( 'wp_query_route_to_rest_api_arg_value', $value, $key, $args );
     }
 
+    return $args;
+  }
+
+  public function build_query ( $parameters ) {
+    $args = $this->sanitize_query_parameters( $parameters );
+
     // Before query: hook your plugins here
     do_action( 'wp_query_route_to_rest_api_before_query', $args );
 
@@ -249,10 +246,23 @@ class WP_Query_Route_To_REST_API extends WP_REST_Posts_Controller {
     // After query: hook your plugins here
     do_action( 'wp_query_route_to_rest_api_after_query', $wp_query );
 
+    return $wp_query;
+  }
+
+  /**
+   * Get a collection of items
+   *
+   * @param WP_REST_Request $request Full data about the request.
+   */
+
+  public function get_items( $request ) {
+    $parameters = $request->get_query_params();
+    $wp_query = $this->build_query( $parameters );
+
     $data = array();
 
     while ( $wp_query->have_posts() ) : $wp_query->the_post();
-      
+
       // Extra safety check for unallowed posts
       if ( $this->check_is_post_allowed( $wp_query->post ) ) {
 
@@ -269,7 +279,7 @@ class WP_Query_Route_To_REST_API extends WP_REST_Posts_Controller {
       }
 
     endwhile;
- 
+
     return $this->get_response( $request, $args, $wp_query, $data );
   }
 
@@ -290,10 +300,10 @@ class WP_Query_Route_To_REST_API extends WP_REST_Posts_Controller {
 
     // Prepare data
     $response = new WP_REST_Response( $data, 200 );
-  
+
     // Total amount of posts
     $response->header( 'X-WP-Total', intval( $wp_query->found_posts ) );
-    
+
     // Total number of pages
     $max_pages = ( absint( $args[ 'posts_per_page' ] ) == 0 ) ? 1 : ceil( $wp_query->found_posts / $args[ 'posts_per_page' ] );
     $response->header( 'X-WP-TotalPages', intval( $max_pages ) );
@@ -360,7 +370,7 @@ class WP_Query_Route_To_REST_API extends WP_REST_Posts_Controller {
    */
 
   protected function check_is_post_allowed( $post ) {
-    
+
     // Is allowed post_status
     if( !$this->check_is_post_status_allowed( $post->post_status ) ) {
       return false;
@@ -378,7 +388,7 @@ class WP_Query_Route_To_REST_API extends WP_REST_Posts_Controller {
   /**
    * Plugin compatibility args
    *
-   * @param array $args 
+   * @param array $args
    *
    * @return array $args
    */
@@ -394,7 +404,7 @@ class WP_Query_Route_To_REST_API extends WP_REST_Posts_Controller {
   /**
    * Plugin compatibility after query
    *
-   * @param WP_Query $wp_query 
+   * @param WP_Query $wp_query
    */
 
   public function plugin_compatibility_after_query( $wp_query ) {
@@ -409,11 +419,25 @@ class WP_Query_Route_To_REST_API extends WP_REST_Posts_Controller {
 }
 
 /**
+ * This allows access to the class instance from other places.
+ */
+
+function wp_query_route_to_rest_api_get_instance() {
+  static $instance;
+
+  if ( ! $instance ) {
+    $instance = new WP_Query_Route_To_REST_API();
+  }
+
+  return $instance;
+}
+
+/**
  * Init only when needed
  */
 
 function wp_query_route_to_rest_api_init() {
-  new WP_Query_Route_To_REST_API();
+  wp_query_route_to_rest_api_get_instance();
 }
 add_action( 'rest_api_init', 'wp_query_route_to_rest_api_init' );
 


### PR DESCRIPTION
I didn't change anything functionality wise. I just created two new class methods, sanitize_query_parameters and build_query, and an additional wp_query_route_to_rest_api_get_instance function which all do what their names imply.

In my case I just did 
```
  function sanitizeArgs($args) {
    if (!function_exists('wp_query_route_to_rest_api_get_instance')) {
      // I should really throw an error instead but that's not the point here
      error_log("Missing dependency aucor/wp_query-route-to-rest-api, QUERIES ARE NOT PROTECTED!"); 

      return $args;
    }

    $externalHelp = \wp_query_route_to_rest_api_get_instance();
    return $externalHelp->sanitize_query_parameters($args);
  }

  public function getHTMLChunk($request) {
    $params = $request->get_params();
    $templates = \k1\getPostListTemplateList();

    $template = $params['template'] ?? null;

     // request url: http://demo.site/wp-json/k1/v1/postlist/query?args={"post_type":["post"],"post_status":%20"draft"}&template=JobListItem
    $args = $this->sanitizeArgs(json_decode($params['args'] ?? null));
``` 

and now my queries can't leak stuff anymore. If I deactivate the plugin, the sample request URL returns the drafts again, and vice versa.

I also updated the version header to 1.2.1, as it was 1.1.something while the release tag was 1.2. In other words you should be able to release this straight from the GitHub UI without any additional work on your part :) 